### PR TITLE
Inventory support for labels, server groups, server metadata and public/private IP addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ UpCloud Collection requires [UpCloud API's Python bindings](https://pypi.org/pro
 newer in order to work. It can be installed from the Python Package Index with the `pip` tool:
 
 ```bash
-pip3 install upcloud-api>=2.0.0
+pip3 install upcloud-api>=2.5.0
 ```
 
 The collection itself can be installed with the `ansible-galaxy` command that comes with the Ansible package:
@@ -67,12 +67,14 @@ You can filter based on multiple data points:
 plugin: community.upcloud.upcloud
 zones:
   - fi-hel2
-tags:
-  - app
-  - db
+labels:
+  - role=prod
+  - foo
 states:
   - started
+connect_with: private_ipv4
 network: 035a0a8a-7704-4da5-820d-129fc8232714
+server_group: Group name or UUID
 ```
 
 Servers can also be grouped by status, zone etc by specifying them as `keyed_groups`.

--- a/plugins/inventory/upcloud.py
+++ b/plugins/inventory/upcloud.py
@@ -218,7 +218,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 for wanted_label in self.get_option("labels"):
                     server_labels = _parse_server_labels(server.labels['label'])
                     for server_label in server_labels:
-                        display.vvvv(f"Comparing {wanted_label} against {server_label}")
+                        display.vvvv(f"Comparing wanted label {wanted_label} against labels {server_label} of server {server.hostname}")
                         if wanted_label in server_label:
                             tmp.append(server)
 

--- a/plugins/inventory/upcloud.py
+++ b/plugins/inventory/upcloud.py
@@ -35,7 +35,7 @@ DOCUMENTATION = r'''
             type: str
             required: false
         connect_with:
-            description: Connect to the server with the specified choice.
+            description: Connect to the server with the specified choice. Server is skipped if chosen type is not available.
             default: public_ipv4
             type: str
             choices:
@@ -43,42 +43,48 @@ DOCUMENTATION = r'''
                 - public_ipv6
                 - hostname
                 - private_ipv4
+                - utility_ipv4
+        server_group:
+            description: Populate inventory with instances in this server group (UUID or title)
+            default: ""
+            type: str
+            required: false
         zones:
-          description: Populate inventory with instances in these zones.
-          default: []
-          type: list
-          elements: str
-          required: false
+            description: Populate inventory with instances in these zones.
+            default: []
+            type: list
+            elements: str
+            required: false
         tags:
-          description: Populate inventory with instances with these tags.
-          default: []
-          type: list
-          elements: str
-          required: false
+            description: Populate inventory with instances with these tags.
+            default: []
+            type: list
+            elements: str
+            required: false
         labels:
-          description: Populate inventory with instances having these labels
-          default: []
-          type: list
-          elements: str
-          required: false
+            description: Populate inventory with instances having all these labels
+            default: []
+            type: list
+            elements: str
+            required: false
         states:
-          description: Populate inventory with instances with these states.
-          default: []
-          type: list
-          elements: str
-          required: false
+            description: Populate inventory with instances with these states.
+            default: []
+            type: list
+            elements: str
+            required: false
         network:
-          description: Populate inventory with instances which are attached to this network name or UUID.
-          default: ""
-          type: str
-          required: false
+            description: Populate inventory with instances which are attached to this network name or UUID.
+            default: ""
+            type: str
+            required: false
 '''
 
 EXAMPLES = r"""
 # Minimal example. `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` are available as environment variables.
 plugin: community.upcloud.upcloud
 
-# Example with locations, types, groups, username and password
+# Example with username and password
 plugin: community.upcloud.upcloud
 username: YOUR_USERNAME
 password: YOUR_PASSWORD
@@ -87,6 +93,16 @@ zones:
 labels:
   - role=prod
   - foo
+
+# Example with locations, labels and server_group
+plugin: community.upcloud.upcloud
+zones:
+  - es-mad1
+  - fi-hel2
+labels:
+  - role=prod
+  - foo
+server_group: group name or uuid
 
 # Group by a zone with prefix e.g. "upcloud_zone_us-nyc1"
 # and state with prefix e.g. "server_state_running"
@@ -116,6 +132,11 @@ except ImportError:
     UC_AVAILABLE = False
 
 
+class NoAvailableAddressException(Exception):
+    """Raised when requested address type is not available"""
+    pass
+
+
 class InventoryModule(BaseInventoryPlugin, Constructable):
     name = 'upcloud'
 
@@ -130,7 +151,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         )
 
         self.client = upcloud_api.CloudManager(self.username, self.password)
-        self.client.api.user_agent = "upcloud-ansible-inventory/{0}".format(__version__)
+        self.client.api.user_agent = f"upcloud-ansible-inventory/{__version__}"
 
         api_root_env = "UPCLOUD_API_ROOT"
         if os.getenv(api_root_env):
@@ -150,6 +171,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _fetch_network_details(self, uuid):
         return self.client.get_network(uuid)
+
+    def _fetch_server_groups(self):
+        return self.client.api.get_request("/server-group/")
 
     def _get_servers(self):
         self.servers = self._fetch_servers()
@@ -194,6 +218,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 disqualified = False
                 for wanted_label in self.get_option("labels"):
                     server_labels = _parse_server_labels(server.labels['label'])
+                    if len(server_labels) == 0:
+                        disqualified = True
+
                     for server_label in server_labels:
                         display.vvvv(f"Comparing {wanted_label} against {server_label}")
                         if wanted_label not in server_label:
@@ -215,28 +242,58 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if getattr(self.network, "servers"):
                 for server in self.servers:
                     for net_server in self.network.servers["server"]:
-                        if server.uuid == net_server.uuid:
+                        if server.uuid == net_server["uuid"]:
                             tmp.append(server)
 
             self.servers = tmp
 
-    def _set_server_attributes(self, server):
+        if self.get_option("server_group"):
+            display.vv("Choosing servers by server group")
+            wanted_group = self.get_option("server_group")
+
+            try:
+                raw_groups = self._fetch_server_groups()
+                groups = raw_groups["server_groups"]["server_group"]
+            except UpCloudAPIError as exp:
+                raise AnsibleError(str(exp))
+
+            tmp = []
+            server_group = None
+            for group in groups:
+                if str(wanted_group).lower() in [group["uuid"].lower(), group["title"].lower()]:
+                    server_group = group["uuid"]
+                    break
+
+            if not server_group:
+                raise AnsibleError(f"Requested server group {wanted_group} does not exist")
+
+            for server in self.servers:
+                if server.server_group == server_group:
+                    tmp.append(server)
+
+            self.servers = tmp
+
+    def _get_server_attributes(self, server):
         server_details = self._fetch_server_details(server.uuid)
 
-        self.inventory.set_variable(server.hostname, "id", to_native(server.uuid))
-        self.inventory.set_variable(server.hostname, "hostname", to_native(server.hostname))
-        self.inventory.set_variable(server.hostname, "state", to_native(server.state))
-        self.inventory.set_variable(server.hostname, "zone", to_native(server.zone))
-        self.inventory.set_variable(server.hostname, "firewall", to_native(server_details.firewall))
-        self.inventory.set_variable(server.hostname, "plan", to_native(server.plan))
-        self.inventory.set_variable(server.hostname, "tags", list(server_details.tags))
-        self.inventory.set_variable(server.hostname, "metadata", to_native(server_details.metadata))
-        self.inventory.set_variable(server.hostname, "labels", list(_parse_server_labels(server.labels["label"])))
+        def _new_attribute(key, attribute):
+            return {"key": key, "attribute": attribute}
+
+        attributes = [
+            _new_attribute("id", to_native(server.uuid)),
+            _new_attribute("hostname", to_native(server.hostname)),
+            _new_attribute("state", to_native(server.state)), _new_attribute("zone", to_native(server.zone)),
+            _new_attribute("firewall", to_native(server_details.firewall)),
+            _new_attribute("plan", to_native(server.plan)), _new_attribute("tags", list(server_details.tags)),
+            _new_attribute("metadata", to_native(server_details.metadata)),
+            _new_attribute("labels", list(_parse_server_labels(server.labels["label"]))),
+            _new_attribute("server_group", to_native(server_details.server_group))
+        ]
 
         ipv4_addrs = []
         ipv6_addrs = []
         publ_addrs = []
-        priv_addrs = []
+        util_addrs = []
         for iface in server_details.networking["interfaces"]["interface"]:
             for addr in iface["ip_addresses"]["ip_address"]:
                 address = addr.get("address")
@@ -245,40 +302,54 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     ipv4_addrs.append(address)
                 else:
                     ipv6_addrs.append(address)
-
                 if iface.get("type") == "public":
                     publ_addrs.append(address)
-                else:
-                    priv_addrs.append(address)
+                if iface.get("type") == "utility":
+                    util_addrs.append(address)
+
+        public_ipv4 = list(set(ipv4_addrs) & set(publ_addrs))
+        public_ipv6 = list(set(ipv6_addrs) & set(publ_addrs))
+
+        # We default to IPv4 when available
+        if len(public_ipv4) > 0:
+            attributes.append(_new_attribute("public_ip", to_native(public_ipv4[0])))
+        elif len(public_ipv6) > 0:
+            attributes.append(_new_attribute("public_ip", to_native(public_ipv4[0])))
+
+        if len(util_addrs) > 0:
+            attributes.append(_new_attribute("utility_ip", to_native(util_addrs[0])))
 
         connect_with = self.get_option("connect_with")
         if connect_with == "public_ipv4":
-            possible_addresses = list(set(ipv4_addrs) & set(publ_addrs))
-            if len(possible_addresses) == 0:
-                raise AnsibleError(
-                    "No available public IPv4 addresses for server {0} ({1})".format(server.uuid, server.hostname)
-                )
-            self.inventory.set_variable(server.hostname, "ansible_host", to_native(possible_addresses[0]))
+            if len(public_ipv4) == 0:
+                raise NoAvailableAddressException(
+                    f"No available public IPv4 addresses for server {server.uuid} ({server.hostname})")
+            attributes.append(_new_attribute("ansible_host", to_native(public_ipv4[0])))
+
         elif connect_with == "public_ipv6":
-            possible_addresses = list(set(ipv6_addrs) & set(publ_addrs))
-            if len(possible_addresses) == 0:
-                raise AnsibleError(
-                    "No available public IPv6 addresses for server {0} ({1})".format(server.uuid, server.hostname)
-                )
-            self.inventory.set_variable(server.hostname, "ansible_host", to_native(possible_addresses[0]))
+            if len(public_ipv6) == 0:
+                raise NoAvailableAddressException(
+                    f"No available public IPv6 addresses for server {server.uuid} ({server.hostname})")
+            attributes.append(_new_attribute("ansible_host", to_native(public_ipv6[0])))
+        elif connect_with == "utility_ipv4":
+            if len(util_addrs) == 0:
+                raise NoAvailableAddressException(
+                    f"No available utility addresses for server {server.uuid} ({server.hostname})")
+            attributes.append(_new_attribute("ansible_host", to_native(util_addrs[0])))
         elif connect_with == "hostname":
-            self.inventory.set_variable(server.hostname, "ansible_host", to_native(server.hostname))
+            attributes.append(_new_attribute("ansible_host", to_native(server.hostname)))
         elif connect_with == "private_ipv4":
             if self.get_option("network"):
                 for iface in server_details.networking["interfaces"]["interface"]:
-                    if iface.network == self.network.uuid:
-                        self.inventory.set_variable(
-                            server.hostname,
+                    if iface["network"] == self.network.uuid:
+                        attributes.append(_new_attribute(
                             "ansible_host",
-                            to_native(iface["ip_addresses"]["ip_address"][0].get("address"))
+                            to_native(iface["ip_addresses"]["ip_address"][0].get("address")))
                         )
             else:
                 raise AnsibleError("You can only connect with private IPv4 if you specify a network")
+
+        return attributes
 
     def verify_file(self, path):
         """Return if a file can be used by this plugin"""
@@ -297,8 +368,21 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.inventory.add_group(group="upcloud")
 
         for server in self.servers:
+            display.vv(f"Evaluating server {server.uuid} ({server.hostname})")
+
+            try:
+                attributes = self._get_server_attributes(server)
+            except NoAvailableAddressException as e:
+                display.vv(str(e))
+                display.v(
+                    f"Skipping server {server.hostname} as it doesn't have requested connection "
+                    f"type ({self.get_option('connect_with')}) available"
+                )
+                continue
+
             self.inventory.add_host(server.hostname, group="upcloud")
-            self._set_server_attributes(server)
+            for attr in attributes:
+                self.inventory.set_variable(server.hostname, attr["key"], attr["attribute"])
 
             strict = self.get_option('strict')
 
@@ -316,7 +400,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         super(InventoryModule, self).parse(inventory, loader, path, cache)
 
         if not UC_AVAILABLE:
-            raise AnsibleError("UpCloud dynamic inventory plugin requires upcloud-api Python module")
+            raise AnsibleError(
+                "UpCloud dynamic inventory plugin requires upcloud-api Python module, "
+                + "see https://pypi.org/project/upcloud-api/")
 
         self._read_config_data(path)
 

--- a/plugins/inventory/upcloud.py
+++ b/plugins/inventory/upcloud.py
@@ -62,7 +62,7 @@ DOCUMENTATION = r'''
             elements: str
             required: false
         labels:
-            description: Populate inventory with instances having all these labels
+            description: Populate inventory with instances with any of these labels, either just key or value ("foo" or "bar") or as a whole tag ("foo=bar")
             default: []
             type: list
             elements: str
@@ -215,19 +215,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             display.vv("Choosing servers by labels")
             tmp = []
             for server in self.servers:
-                disqualified = False
                 for wanted_label in self.get_option("labels"):
                     server_labels = _parse_server_labels(server.labels['label'])
-                    if len(server_labels) == 0:
-                        disqualified = True
-
                     for server_label in server_labels:
                         display.vvvv(f"Comparing {wanted_label} against {server_label}")
-                        if wanted_label not in server_label:
-                            disqualified = True
-
-                if not disqualified:
-                    tmp.append(server)
+                        if wanted_label in server_label:
+                            tmp.append(server)
 
             self.servers = tmp
 

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/inventory/upcloud.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
This PR brings in following updates:
* Servers without matching interface (`connect_with` that is `public_ipv4` by default) are skipped so other servers can be accessed. Skipped ones are logged.
* Support for filtering with server labels
* Support for filtering with server group