### PR TITLE
feat(inventory): add `labels_operator` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `labels_operator` option to inventory plugin to select how matching with multiple labels is done. I.e., add option to select only servers that have all of the specified labels.
+
+### Changed
+
+- Accept list of values for `network` to allow filtering with multiple networks. Server is included if it is attached to any of the specified networks.
+
 ## [0.10.0] - 2026-04-08
 
 ### Changed

--- a/plugins/inventory/servers.py
+++ b/plugins/inventory/servers.py
@@ -75,10 +75,21 @@ DOCUMENTATION = r'''
             elements: str
             required: false
         labels:
-            description: Populate inventory with instances with any of these labels, either just key or value ("foo" or "bar") or as a whole tag ("foo=bar")
+            description: >
+                Populate inventory with servers that have matching labels. You can define the labels as key, value, or key-value pair (e.g. V("env"),
+                V("prod"), or V("env=prod")). By default, server is included if it has any of the specified labels. Use O(labels_operator) to change this
+                behavior.
             default: []
             type: list
             elements: str
+            required: false
+        labels_operator:
+            description: Operator to use when filtering servers by labels.
+            default: "or"
+            type: str
+            choices:
+                - and
+                - or
             required: false
         states:
             description: Populate inventory with instances with these states.
@@ -87,9 +98,12 @@ DOCUMENTATION = r'''
             elements: str
             required: false
         network:
-            description: Populate inventory with instances which are attached to this network name or UUID.
+            description: >
+                Populate inventory with servers that are attached to any of the given networks. Value can be network UUID, V("public"), or V("utility"). First
+                matching private network is used as C(ansible_host) when using O(connect_with=private_ipv4).
             default: ""
-            type: str
+            type: list
+            elements: str
             required: false
 '''
 
@@ -173,10 +187,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         return self.client.get_servers()
 
     def _fetch_server_details(self, uuid):
-        return self.client.get_server(uuid)
+        try:
+            return self._servers[uuid]
+        except AttributeError:
+            self._servers = {}
+            self._servers[uuid] = self.client.get_server(uuid)
+        except KeyError:
+            self._servers[uuid] = self.client.get_server(uuid)
 
-    def _fetch_network_details(self, uuid):
-        return self.client.get_network(uuid)
+        return self._servers[uuid]
 
     def _fetch_server_groups(self):
         return self.client.api.get_request("/server-group/")
@@ -221,28 +240,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             display.vv("Choosing servers by labels")
             tmp = []
             for server in self.servers:
-                for wanted_label in self.get_option("labels"):
-                    server_labels = _parse_server_labels(server.labels['label'])
-                    for server_label in server_labels:
-                        display.vvvv(f"Comparing wanted label {wanted_label} against labels {server_label} of server {server.hostname}")
-                        if wanted_label in server_label:
-                            tmp.append(server)
+                if _match_by_labels(server, self.get_option("labels"), self.get_option("labels_operator")):
+                    tmp.append(server)
 
             self.servers = tmp
 
-        if self.get_option("network"):
+        networks = _ensure_list(self.get_option("network"))
+        if networks:
             display.vv("Choosing servers by network")
-            try:
-                self.network = self._fetch_network_details(self.get_option("network"))
-            except UpCloudAPIError as exp:
-                raise AnsibleError(str(exp))
-
             tmp = []
-            if getattr(self.network, "servers"):
-                for server in self.servers:
-                    for net_server in self.network.servers["server"]:
-                        if server.uuid == net_server["uuid"]:
-                            tmp.append(server)
+
+            for server in self.servers:
+                server_details = self._fetch_server_details(server.uuid)
+                if _match_by_networks(server_details, networks):
+                    tmp.append(server)
 
             self.servers = tmp
 
@@ -274,6 +285,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _get_ansible_host(self, public_ipv4, public_ipv6, util_addrs, server, server_details):
         connect_with = _ensure_list(self.get_option("connect_with"))
+        networks = _ensure_list(self.get_option("network"))
 
         for method in connect_with:
             display.vv(f'Trying to find {method} connection method for server {server.uuid} ({server.hostname})')
@@ -300,10 +312,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if method == "hostname":
                 return server.hostname
             if method == "private_ipv4":
-                if self.get_option("network"):
-                    for iface in server_details.networking["interfaces"]["interface"]:
-                        if iface["network"] == self.network.uuid:
-                            return iface["ip_addresses"]["ip_address"][0].get("address")
+                if networks:
+                    for network in networks:
+                        for iface in server_details.networking["interfaces"]["interface"]:
+                            if iface["network"] == network:
+                                return iface["ip_addresses"]["ip_address"][0].get("address")
                 else:
                     raise AnsibleError("You can only connect with private IPv4 if you specify a network")
 
@@ -420,7 +433,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
 
 def _ensure_list(value) -> List:
-    if value is None:
+    if value is None or value == "":
         return []
 
     if isinstance(value, list):
@@ -441,3 +454,29 @@ def _parse_server_labels(labels: List):
         processed.append(f"{label['key']}={label['value']}")
 
     return processed
+
+
+def _match_by_labels(server, match_labels, operator):
+    for match_label in match_labels:
+        server_labels = _parse_server_labels(server.labels['label'])
+        match_found = False
+        for server_label in server_labels:
+            display.vvvv(f"Comparing wanted label {match_label} against labels {server_label} of server {server.hostname}")
+            if match_label in server_label:
+                match_found = True
+                if operator == "or":
+                    return True
+
+        if operator == "and" and not match_found:
+            return False
+
+    return operator == "and"
+
+
+def _match_by_networks(server_details, networks):
+    for network in networks:
+        for iface in server_details.networking["interfaces"]["interface"]:
+            if iface["type"] == network or iface["network"] == network:
+                return True
+
+    return False

--- a/tests/unit/plugins/inventory/test_upcloud.py
+++ b/tests/unit/plugins/inventory/test_upcloud.py
@@ -437,31 +437,80 @@ def test_populate_hostvars(inventory, mocker):
     assert host2.vars['labels'][0] == "foo=bar"
 
 
-def get_filtered_labeled_option(option):
+def get_filtering_with_labels_or_options(option):
     options = {
         'plugin': 'upcloud.cloud.servers',
-        'connect_with': ['public_ipv4'],
+        'connect_with': ['public_ipv4', 'private_ipv4'],
         'labels': ['foo=bar'],
+        'network': ["public", '035146a5-7a85-408b-b1f8-21925164a7d3'],
     }
     return options.get(option)
 
 
-def test_filtering_with_labels(inventory, mocker):
+def test_filtering_with_labels_or(inventory, mocker):
     inventory._fetch_servers = mocker.MagicMock(side_effect=get_servers)
     inventory._fetch_server_details = mocker.MagicMock(side_effect=get_server_details)
-    inventory.get_option = mocker.MagicMock(side_effect=get_filtered_labeled_option)
+    inventory.get_option = mocker.MagicMock(side_effect=get_filtering_with_labels_or_options)
 
     inventory._initialize_upcloud_client = _mock_initialize_client
     inventory._test_upcloud_credentials = _mock_test_credentials
 
     inventory._populate()
 
-    assert len(inventory.inventory.hosts) == 1
+    assert len(inventory.inventory.hosts) == 2
     host2 = inventory.inventory.get_host('server2')
-    # host3 has the label, but it is filtered out by connect_with
+    host3 = inventory.inventory.get_host('server3')
 
     assert host2.vars['id'] == "004d5201-e2ff-4325-7ac6-a274f1c517b7"
     assert host2.vars['labels'][0] == "foo=bar"
+
+    assert host3.vars['id'] == "0003295f-343a-44a2-8080-fb8196a6802a"
+
+
+def get_filtering_with_labels_or_options(option):
+    options = {
+        'plugin': 'upcloud.cloud.servers',
+        'connect_with': ['public_ipv4', 'private_ipv4'],
+        'labels': ['foo=bar'],
+        'labels_operator': 'or',
+        'network': ["public", '035146a5-7a85-408b-b1f8-21925164a7d3'],
+    }
+    return options.get(option)
+
+
+def get_filtering_with_labels_and_options(option):
+    options = {
+        'plugin': 'upcloud.cloud.servers',
+        'connect_with': ['public_ipv4', 'private_ipv4'],
+        'labels': [
+            'foo=bar',
+            'private=yes',
+        ],
+        'labels_operator': 'and',
+        'network': ["public", '035146a5-7a85-408b-b1f8-21925164a7d3'],
+    }
+    return options.get(option)
+
+
+def test_filtering_with_labels_and(inventory, mocker):
+    inventory._fetch_servers = mocker.MagicMock(side_effect=get_servers)
+    inventory._fetch_server_details = mocker.MagicMock(side_effect=get_server_details)
+    inventory.get_option = mocker.MagicMock(side_effect=get_filtering_with_labels_and_options)
+
+    inventory._initialize_upcloud_client = _mock_initialize_client
+    inventory._test_upcloud_credentials = _mock_test_credentials
+
+    inventory._fetch_network_details = get_network_details
+
+    inventory._populate()
+
+    assert len(inventory.inventory.hosts) == 1
+    host3 = inventory.inventory.get_host('server3')
+
+    assert host3.vars['id'] == "0003295f-343a-44a2-8080-fb8196a6802a"
+    assert len(host3.vars['labels']) == 2
+    assert host3.vars['labels'][0] == "foo=bar"
+    assert host3.vars['labels'][1] == "private=yes"
 
 
 def get_filtered_connect_with_option(option):


### PR DESCRIPTION
This allows selecting servers that have all of the given labels (instead of any of the given labels).

Implements #40 